### PR TITLE
[REG-1495] Update reference to 'gg.regression.unity.bots'

### DIFF
--- a/Assets/Match 3 Starter/Scenes/MenuSettings.lighting
+++ b/Assets/Match 3 Starter/Scenes/MenuSettings.lighting
@@ -1,0 +1,64 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!850595691 &4890085278179872738
+LightingSettings:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: MenuSettings
+  serializedVersion: 4
+  m_GIWorkflowMode: 1
+  m_EnableBakedLightmaps: 0
+  m_EnableRealtimeLightmaps: 0
+  m_RealtimeEnvironmentLighting: 1
+  m_BounceScale: 1
+  m_AlbedoBoost: 1
+  m_IndirectOutputScale: 1
+  m_UsingShadowmask: 0
+  m_BakeBackend: 0
+  m_LightmapMaxSize: 1024
+  m_BakeResolution: 40
+  m_Padding: 2
+  m_LightmapCompression: 3
+  m_AO: 0
+  m_AOMaxDistance: 1
+  m_CompAOExponent: 1
+  m_CompAOExponentDirect: 0
+  m_ExtractAO: 0
+  m_MixedBakeMode: 1
+  m_LightmapsBakeMode: 1
+  m_FilterMode: 1
+  m_LightmapParameters: {fileID: 15204, guid: 0000000000000000f000000000000000, type: 0}
+  m_ExportTrainingData: 0
+  m_TrainingDataDestination: TrainingData
+  m_RealtimeResolution: 2
+  m_ForceWhiteAlbedo: 0
+  m_ForceUpdates: 0
+  m_FinalGather: 0
+  m_FinalGatherRayCount: 256
+  m_FinalGatherFiltering: 1
+  m_PVRCulling: 1
+  m_PVRSampling: 1
+  m_PVRDirectSampleCount: 32
+  m_PVRSampleCount: 512
+  m_PVREnvironmentSampleCount: 512
+  m_PVREnvironmentReferencePointCount: 2048
+  m_LightProbeSampleCountMultiplier: 4
+  m_PVRBounces: 2
+  m_PVRMinBounces: 2
+  m_PVREnvironmentMIS: 0
+  m_PVRFilteringMode: 0
+  m_PVRDenoiserTypeDirect: 0
+  m_PVRDenoiserTypeIndirect: 0
+  m_PVRDenoiserTypeAO: 0
+  m_PVRFilterTypeDirect: 0
+  m_PVRFilterTypeIndirect: 0
+  m_PVRFilterTypeAO: 0
+  m_PVRFilteringGaussRadiusDirect: 1
+  m_PVRFilteringGaussRadiusIndirect: 5
+  m_PVRFilteringGaussRadiusAO: 2
+  m_PVRFilteringAtrousPositionSigmaDirect: 0.5
+  m_PVRFilteringAtrousPositionSigmaIndirect: 2
+  m_PVRFilteringAtrousPositionSigmaAO: 1
+  m_PVRTiledBaking: 0

--- a/Assets/Match 3 Starter/Scenes/MenuSettings.lighting.meta
+++ b/Assets/Match 3 Starter/Scenes/MenuSettings.lighting.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: aef2500f6ae4a437faa75f701c3df7d1
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 4890085278179872738
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/RegressionGames/Runtime.meta
+++ b/Assets/RegressionGames/Runtime.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: c3e222a1965c1495b86fd181a452a6c1
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/RegressionGames/Runtime/GeneratedScripts.meta
+++ b/Assets/RegressionGames/Runtime/GeneratedScripts.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 6299950bd2e9a4694bd577771f408c14
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/RegressionGames/Runtime/GeneratedScripts/RGActionMap.cs
+++ b/Assets/RegressionGames/Runtime/GeneratedScripts/RGActionMap.cs
@@ -1,0 +1,17 @@
+/*
+* This file has been automatically generated. Do not modify.
+*/
+
+using System;
+
+namespace RGCutie_Tutti_Frutti___Match_3
+{
+    using UnityEngine;
+
+    public class RGActionMap : MonoBehaviour
+    {
+        private void Awake()
+        {
+        }
+    }
+}

--- a/Assets/RegressionGames/Runtime/GeneratedScripts/RGActionMap.cs.meta
+++ b/Assets/RegressionGames/Runtime/GeneratedScripts/RGActionMap.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6764f6c03825345938ee2bbb3bf2f2e5
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/RegressionGames/Runtime/GeneratedScripts/RGSerialization.cs
+++ b/Assets/RegressionGames/Runtime/GeneratedScripts/RGSerialization.cs
@@ -1,0 +1,15 @@
+/*
+* This file has been automatically generated. Do not modify.
+*/
+
+using System;
+using Newtonsoft.Json;
+
+namespace RGCutie_Tutti_Frutti___Match_3
+{
+    using UnityEngine;
+
+    public static class RGSerialization
+    {
+    }
+}

--- a/Assets/RegressionGames/Runtime/GeneratedScripts/RGSerialization.cs.meta
+++ b/Assets/RegressionGames/Runtime/GeneratedScripts/RGSerialization.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1cf91f743d41042dcb284144cec1239c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/UserSettings.meta
+++ b/Assets/UserSettings.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: ec2b46572b12a4959aab7b44d719bfd8
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/UserSettings/RGUserSettings.asset
+++ b/Assets/UserSettings/RGUserSettings.asset
@@ -1,0 +1,16 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a1150c4d27dd34cf694489b35177f64e, type: 3}
+  m_Name: RGUserSettings
+  m_EditorClassIdentifier: 
+  email: 
+  password: 

--- a/Assets/UserSettings/RGUserSettings.asset.meta
+++ b/Assets/UserSettings/RGUserSettings.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: fa6b3a3e9ea264aa6afc28d3a8953d74
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -9,7 +9,7 @@
     "com.unity.timeline": "1.6.4",
     "com.unity.ugui": "1.0.0",
     "com.unity.visualscripting": "1.8.0",
-    "gg.regression.unity.bots": "https://github.com/Regression-Games/RGUnityBots.git?path=src/gg.regression.unity.bots#ashley/reg-1495",
+    "gg.regression.unity.bots": "https://github.com/Regression-Games/RGUnityBots.git?path=src/gg.regression.unity.bots",
     "com.unity.modules.ai": "1.0.0",
     "com.unity.modules.androidjni": "1.0.0",
     "com.unity.modules.animation": "1.0.0",

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -9,7 +9,7 @@
     "com.unity.timeline": "1.6.4",
     "com.unity.ugui": "1.0.0",
     "com.unity.visualscripting": "1.8.0",
-    "gg.regression.unity.bots": "https://github.com/Regression-Games/RGUnityBots.git",
+    "gg.regression.unity.bots": "https://github.com/Regression-Games/RGUnityBots.git?path=src/gg.regression.unity.bots#ashley/reg-1495",
     "com.unity.modules.ai": "1.0.0",
     "com.unity.modules.androidjni": "1.0.0",
     "com.unity.modules.animation": "1.0.0",

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -107,7 +107,7 @@
       "url": "https://packages.unity.com"
     },
     "gg.regression.unity.bots": {
-      "version": "https://github.com/Regression-Games/RGUnityBots.git?path=src/gg.regression.unity.bots#ashley/reg-1495",
+      "version": "https://github.com/Regression-Games/RGUnityBots.git?path=src/gg.regression.unity.bots",
       "depth": 0,
       "source": "git",
       "dependencies": {
@@ -115,7 +115,7 @@
         "com.unity.textmeshpro": "3.0.6",
         "com.unity.inputsystem": "1.5.1"
       },
-      "hash": "8d671eecf7e1c4b01e4688405cd7b5740750af90"
+      "hash": "c0af47aa049e46d990b14d397aa52986c1f1daf6"
     },
     "com.unity.modules.ai": {
       "version": "1.0.0",

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -39,6 +39,15 @@
       "dependencies": {},
       "url": "https://packages.unity.com"
     },
+    "com.unity.inputsystem": {
+      "version": "1.5.1",
+      "depth": 1,
+      "source": "registry",
+      "dependencies": {
+        "com.unity.modules.uielements": "1.0.0"
+      },
+      "url": "https://packages.unity.com"
+    },
     "com.unity.nuget.newtonsoft-json": {
       "version": "3.1.0",
       "depth": 1,
@@ -98,14 +107,15 @@
       "url": "https://packages.unity.com"
     },
     "gg.regression.unity.bots": {
-      "version": "https://github.com/Regression-Games/RGUnityBots.git",
+      "version": "https://github.com/Regression-Games/RGUnityBots.git?path=src/gg.regression.unity.bots#ashley/reg-1495",
       "depth": 0,
       "source": "git",
       "dependencies": {
         "com.unity.nuget.newtonsoft-json": "3.1.0",
-        "com.unity.textmeshpro": "3.0.6"
+        "com.unity.textmeshpro": "3.0.6",
+        "com.unity.inputsystem": "1.5.1"
       },
-      "hash": "b0abe2ca8696945aec9679952b296a7b8b9b0c54"
+      "hash": "8d671eecf7e1c4b01e4688405cd7b5740750af90"
     },
     "com.unity.modules.ai": {
       "version": "1.0.0",

--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -871,7 +871,7 @@ PlayerSettings:
     m_VersionCode: 1
     m_VersionName: 
   apiCompatibilityLevel: 6
-  activeInputHandler: 0
+  activeInputHandler: 2
   windowsGamepadBackendHint: 0
   cloudProjectId: 
   framebufferDepthMemorylessMode: 0


### PR DESCRIPTION
Updates reference to RGUnityBots to react to https://github.com/Regression-Games/RGUnityBots/pull/121

This does not check or correct any other issues that may exist in the sample. I did ensure the Unity project loads and resolves the package correctly, and load the project which may have caused generated code to be re-generated.

--

TODO:
* [x] Reopen after merging https://github.com/Regression-Games/RGUnityBots/pull/121 to ensure `package-lock.json` gets updated with the right hash.